### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Relationreport/Form/Report/RelationshipOverview.php
+++ b/CRM/Relationreport/Form/Report/RelationshipOverview.php
@@ -117,7 +117,7 @@ class CRM_Relationreport_Form_Report_RelationshipOverview extends CRM_Report_For
               $select[] = " GROUP_CONCAT(DISTINCT {$contact_table}.display_name ORDER BY {$contact_table}.display_name ASC SEPARATOR ', ') AS {$tableName}_{$fieldName} ";
               $select[] = " GROUP_CONCAT(DISTINCT {$contact_table}.id ORDER BY {$contact_table}.display_name ASC SEPARATOR ', ') AS {$tableName}_{$fieldName}_id ";
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type']  = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type']  = $field['type'] ?? NULL;
               $this->_columnHeaders["{$tableName}_{$fieldName}_id"]['title'] = $field['title'] . '_id';
               $this->_columnHeaders["{$tableName}_{$fieldName}_id"]['type']  = CRM_Utils_Type::T_INT;
               $this->_columnHeaders["{$tableName}_{$fieldName}_id"]['no_display']  = TRUE;
@@ -125,13 +125,13 @@ class CRM_Relationreport_Form_Report_RelationshipOverview extends CRM_Report_For
               // tags should be included as an aggregated field as well
               $select[] = " GROUP_CONCAT(DISTINCT(tag.name) SEPARATOR ', ') AS {$tableName}_{$fieldName} ";
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type']  = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type']  = $field['type'] ?? NULL;
 
             } else {
               // default field            
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type']  = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type']  = $field['type'] ?? NULL;
             }
           }
         }
@@ -191,20 +191,20 @@ class CRM_Relationreport_Form_Report_RelationshipOverview extends CRM_Report_For
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('operatorType', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from     = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to       = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from     = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to       = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,
-                CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
+                $this->_params["{$fieldName}_value"] ?? NULL,
+                $this->_params["{$fieldName}_min"] ?? NULL,
+                $this->_params["{$fieldName}_max"] ?? NULL
               );
             }
           }


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.